### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -35,7 +35,7 @@ module "application_insights_preview" {
 }
 
 moved {
-  from = azurerm_application_insights.appinsights_preview
+  from = azurerm_application_insights.appinsights_preview[0]
   to   = module.application_insights_preview[0].azurerm_application_insights.this
 }
 resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY_PREVIEW" {

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -1,47 +1,46 @@
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.env}"
-  location            = var.appinsights_location
-  resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-  
-  tags = var.common_tags
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+  env     = var.env
+  product = var.product
+  name    = var.product
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.appinsights_location
+  common_tags         = var.common_tags
+}
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
 }
 
 resource "azurerm_key_vault_secret" "appInsights-InstrumentationKey" {
   name         = "AppInsightsInstrumentationKey"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.adoption-app-vault.key_vault_id
 }
 
-resource "azurerm_application_insights" "appinsights_preview" {
-  name                = "${var.product}-appinsights-preview"
-  location            = var.location
+module "application_insights_preview" {
+  count  = var.env == "aat" ? 1 : 0
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = "preview"
+  product = var.product
+  name    = "${var.product}-appinsights"
+
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-  count = var.env == "aat" ? 1 : 0
 
-  tags = var.common_tags
-
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance..
-      application_type,
-    ]
-  }
+  common_tags = var.common_tags
 }
 
+moved {
+  from = azurerm_application_insights.appinsights_preview
+  to   = module.application_insights_preview[0].azurerm_application_insights.this
+}
 resource "azurerm_key_vault_secret" "AZURE_APPINSIGHTS_KEY_PREVIEW" {
   name         = "AppInsightsInstrumentationKey-Preview-New"
-  value        = azurerm_application_insights.appinsights_preview[0].instrumentation_key
+  value        = module.application_insights_preview[0].instrumentation_key
   key_vault_id = module.adoption-app-vault.key_vault_id
-  count = var.env == "aat" ? 1 : 0
+  count        = var.env == "aat" ? 1 : 0
 }

--- a/state.tf
+++ b/state.tf
@@ -4,12 +4,12 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.33.0"
+      version = "3.84.0"
     }
     random = {
       source = "hashicorp/random"
     }
-}
+  }
 }
 provider "azurerm" {
   features {}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.