### PR TITLE
ADOP-2789: Migrate application insights to UK South

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following parameters are optional
 - `product` The (short) name of the product. Default is "adoption". 
 - `location` The location of the Azure data center. Default is "UK South".
 - `appinsights_location` Location for Application Insights. Default is "West Europe".
+  * Deprecated as of [ADOP-2789](https://tools.hmcts.net/jira/browse/ADOP-2789) - use `location` instead.
 - `application_type` Type of Application Insights (Web/Other). Default is "Web".
 
 ### Output

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -16,7 +16,7 @@ module "application_insights_uksouth" {
 
   env     = var.env
   product = var.product
-  name    = var.product
+  name    = "${var.product}-appinsights-uksouth"
 
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -11,14 +11,27 @@ module "application_insights" {
   common_tags         = var.common_tags
 }
 
+module "application_insights_uksouth" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=4.x"
+
+  env     = var.env
+  product = var.product
+  name    = var.product
+
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+  alert_location      = var.location
+  common_tags         = var.common_tags
+}
+
 moved {
   from = azurerm_application_insights.appinsights
-  to   = module.application_insights.azurerm_application_insights.this
+  to   = module.application_insights_uksouth.azurerm_application_insights.this
 }
 
 resource "azurerm_key_vault_secret" "appInsights-InstrumentationKey" {
   name         = "AppInsightsInstrumentationKey"
-  value        = module.application_insights.instrumentation_key
+  value        = module.application_insights_uksouth.instrumentation_key
   key_vault_id = module.adoption-app-vault.key_vault_id
 }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ADOP-2789

Created a new application insights module with the location variable set to "UK South".

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [] Yes
  * [x] No

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change
