### PR TITLE
ADOP-2789: Updating & pinning azureRM provider version to 4.42.0

### DIFF
--- a/state.tf
+++ b/state.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "4.0.0"
+      version = "=4.42.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ADOP-2789

Further changes after merging original 'ADOP-2789-demo' branch into master - updating & pinning azureRM version to 4.42.0

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change
