### PR TITLE
ADOP-2789: Setting alert_location for appinsights module to its default value (global)

### DIFF
--- a/application-insights.tf
+++ b/application-insights.tf
@@ -20,7 +20,7 @@ module "application_insights_uksouth" {
 
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
-  alert_location      = var.location
+  alert_location      = "global"
   common_tags         = var.common_tags
 }
 

--- a/application-insights.tf
+++ b/application-insights.tf
@@ -20,7 +20,7 @@ module "application_insights_uksouth" {
 
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
-  alert_location      = "global"
+  alert_location      = var.alert_location
   common_tags         = var.common_tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "appinsights_location" {
 }
 
 variable "alert_location" {
-  default    = "West Europe"
+  default     = "West Europe"
   description = "Location for Action Groups"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,11 @@ variable "appinsights_location" {
   description = "Location for Application Insights"
 }
 
+variable "alert_location" {
+  default    = "West Europe"
+  description = "Location for Action Groups"
+}
+
 variable "common_tags" {
   type = map(any)
 }


### PR DESCRIPTION
[ADOP-2789](https://tools.hmcts.net/jira/browse/ADOP-2789)

Further changes after [first](https://github.com/hmcts/adoption-shared-infrastructure/pull/33) & [second](https://github.com/hmcts/adoption-shared-infrastructure/pull/34) PR branches were deleted - setting the 'alert_location' input for the application insights module to its default value of 'global'. 

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [] Yes
  * [x] No

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [] Does this PR introduce a breaking change
