### PR TITLE
ADOP-2856 Jenkins Library Upgrade

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure@2.5.0") _
+@Library("Infrastructure@2.5.4") _
 
 def branchesToSync = ['demo', 'ithc', 'perftest']
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure") _
+@Library("Infrastructure@2.5.0") _
 
 def branchesToSync = ['demo', 'ithc', 'perftest']
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure@2.5.0") _
+@Library("Infrastructure@2.5.4") _
 
 //noinspection GroovyAssignabilityCheck
 properties([

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -1,6 +1,6 @@
 #!groovy
 //noinspection GroovyUnusedAssignment
-@Library("Infrastructure") _
+@Library("Infrastructure@2.5.0") _
 
 //noinspection GroovyAssignabilityCheck
 properties([

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -10,6 +10,7 @@ module "adoption-app-vault" {
   common_tags                = local.tags
   create_managed_identity    = true
   managed_identity_object_id = data.azurerm_user_assigned_identity.jenkins.principal_id
+  grant_preview_jenkins_access = var.env == "aat"
 }
 
 output "vaultName" {

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,15 +1,15 @@
 module "adoption-app-vault" {
-  source                     = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  name                       = "${var.product}-${var.env}"
-  product                    = var.product
-  env                        = var.env
-  tenant_id                  = var.tenant_id
-  object_id                  = var.jenkins_AAD_objectId
-  resource_group_name        = azurerm_resource_group.rg.name
-  product_group_name         = "DTS Adoption"
-  common_tags                = local.tags
-  create_managed_identity    = true
-  managed_identity_object_id = data.azurerm_user_assigned_identity.jenkins.principal_id
+  source                       = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                         = "${var.product}-${var.env}"
+  product                      = var.product
+  env                          = var.env
+  tenant_id                    = var.tenant_id
+  object_id                    = var.jenkins_AAD_objectId
+  resource_group_name          = azurerm_resource_group.rg.name
+  product_group_name           = "DTS Adoption"
+  common_tags                  = local.tags
+  create_managed_identity      = true
+  managed_identity_object_id   = data.azurerm_user_assigned_identity.jenkins.principal_id
   grant_preview_jenkins_access = var.env == "aat"
 }
 

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,5 +1,5 @@
 module "adoption-app-vault" {
-  source                       = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  source                       = "git@github.com:hmcts/cnp-module-key-vault?ref=DTSPO-31965/remove-jenkins-ptl-access"
   name                         = "${var.product}-${var.env}"
   product                      = var.product
   env                          = var.env


### PR DESCRIPTION
### Jira link
[ADOP-2856](https://tools.hmcts.net/jira/browse/ADOP-2856)

### Change description

- Set Jenkins library version to 2.5.4
- Enable Preview pipeline to access AAT keyvault

### Testing done


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] Does this PR introduce a breaking change - key vault pointed at specific branch, needs to be reverted to master once PlatOps change goes live.
